### PR TITLE
Add certificate_name variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://travis-ci.com/telia-oss/terraform-aws-acm-certificate.svg?branch=master)](https://travis-ci.com/telia-oss/terraform-aws-acm-certificate)
 
-Use this module for creating and validating an ACM certificate. Bear in mind  that the validation does not represent a real-world entity in AWS, therefore changing or deleting it on its own has no immediate effect.
+Use this module for creating and validating an ACM certificate. Bear in mind  that the validation does not represent a real-world 
+entity in AWS, therefore changing or deleting it on its own has no immediate effect.
 
 ## Examples
 
@@ -10,7 +11,21 @@ Use this module for creating and validating an ACM certificate. Bear in mind  th
 
 ### Notes
 
-For use in an automated pipeline consider setting the wait_for_validation variable to false.  If this is not set this module will cause terraform to wait until validation is complete or error after a 45 minute timeout.
+For use in an automated pipeline consider setting the wait_for_validation variable to false.  If this is not set this module 
+will cause terraform to wait until validation is complete or error after a 45 minute timeout.
+
+## Usage and gotchas
+Due to the fact that both the wildcard certificate for a domain/subdomain (e.g *.test.exmple.com) and a site certificate 
+(e.g test.example.com) requests use the same DNS valididation record it is important to request both at the same time if 
+you need both. In this case set the optional `create_wildcard` parameter to `"true"`
+
+Do not request a certificate for the site `"*"` and select create_wildcard = `"true"` in the same request
+### Wildcard at the top of your domain/subdomain
+To serve a site at the top of your domain  (e.g. https://example.com) you will need to request a certificate for the site 
+`"*"` in the hosted zone. You may also want to read here for how to set the DNS record -  
+https://aws.amazon.com/premiumsupport/knowledge-center/route-53-create-alias-records/
+
+
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Due to the fact that both the wildcard certificate for a domain/subdomain (e.g *
 (e.g test.example.com) requests use the same DNS valididation record it is important to request both at the same time if 
 you need both. In this case set the optional `create_wildcard` parameter to `"true"`
 
-Do not request a certificate for the site `"*"` and select create_wildcard = `"true"` in the same request
+Do not request a certificate that includes a wildcard and select create_wildcard = `"true"` in the same request
 ### Wildcard at the top of your domain/subdomain
-To serve a site at the top of your domain  (e.g. https://example.com) you will need to request a certificate for the site 
-`"*"` in the hosted zone. You may also want to read here for how to set the DNS record -  
+To serve a site at the top of your domain  (e.g. https://example.com) you will need to request a certificate with the same 
+name as hosted zone. You may also want to read here for how to set the DNS record -  
 https://aws.amazon.com/premiumsupport/knowledge-center/route-53-create-alias-records/
 
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  version             = "1.52.0"
+  version             = "1.56.0"
   region              = "eu-west-1"
   allowed_account_ids = ["<test-account-id>"]
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -21,7 +21,8 @@ provider "aws" {
 module "certificate" {
   source = "../../"
   domain = "<route53-zone-name>"
-  host = "default-test"
+  host   = "default-test"
+
   tags {
     environment = "dev"
     terraform   = "True"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -21,7 +21,7 @@ provider "aws" {
 module "certificate" {
   source = "../../"
   domain = "<route53-zone-name>"
-
+  host = "default-test"
   tags {
     environment = "dev"
     terraform   = "True"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -21,7 +21,7 @@ provider "aws" {
 module "certificate" {
   source = "../../"
   domain = "<route53-zone-name>"
-  host   = "default-test"
+  site   = "default-test"
 
   tags {
     environment = "dev"

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -19,9 +19,9 @@ provider "aws" {
 }
 
 module "certificate" {
-  source = "../../"
-  domain = "<route53-zone-name>"
-  site   = "default-test"
+  source           = "../../"
+  hosted_zone_name = "<route53-zone-name>"
+  certificate_name = "default-test.<route53-zone-name>"
 
   tags {
     environment = "dev"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Resource
 # ------------------------------------------------------------------------------
 resource "aws_acm_certificate" "main" {
-  domain_name       = "${var.host}.${var.domain}"
+  domain_name       = "${var.site}.${var.domain}"
   validation_method = "DNS"
   tags              = "${var.tags}"
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Resource
 # ------------------------------------------------------------------------------
 resource "aws_acm_certificate" "main" {
-  domain_name       = "${var.domain}"
+  domain_name       = "${var.host}.${var.domain}"
   validation_method = "DNS"
   tags              = "${var.tags}"
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ data "aws_route53_zone" "main" {
 
 resource "aws_acm_certificate" "wildcard" {
   count             = "${var.create_wildcard == "true" ? 1 : 0}"
-  domain_name       = "*.${var.domain}"
+  domain_name       = "*.${var.site}.${var.domain}"
   validation_method = "DNS"
   tags              = "${var.tags}"
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 # Resource
 # ------------------------------------------------------------------------------
 resource "aws_acm_certificate" "main" {
-  domain_name       = "${var.site}.${var.domain}"
+  domain_name       = "${var.certificate_name}"
   validation_method = "DNS"
   tags              = "${var.tags}"
 
@@ -11,13 +11,17 @@ resource "aws_acm_certificate" "main" {
   }
 }
 
+locals {
+  test = "${var.create_wildcard == "true" ? 1 : 0}"
+}
+
 data "aws_route53_zone" "main" {
-  name = "${var.domain}"
+  name = "${var.hosted_zone_name}"
 }
 
 resource "aws_acm_certificate" "wildcard" {
   count             = "${var.create_wildcard == "true" ? 1 : 0}"
-  domain_name       = "*.${var.site}.${var.domain}"
+  domain_name       = "*.${var.certificate_name}"
   validation_method = "DNS"
   tags              = "${var.tags}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,8 +5,8 @@ variable "domain" {
   description = "The hosted zone/domian name"
 }
 
-variable "host" {
-  description = "The specific host to create a certificate for. (the name before the first .)"
+variable "site" {
+  description = "The specific site to create a certificate for. (the name before the first .)"
 }
 
 variable "create_wildcard" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,11 @@
 # Variables
 # ------------------------------------------------------------------------------
 variable "domain" {
-  description = "The domain of the certificate to look up."
+  description = "The hosted zone/domian name"
+}
+
+variable "host" {
+  description = "The specific host to create a certificate for. (the name before the first .)"
 }
 
 variable "create_wildcard" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
-variable "domain" {
-  description = "The hosted zone/domian name"
+variable "hosted_zone_name" {
+  description = "The hosted zone"
 }
 
-variable "site" {
-  description = "The specific site to create a certificate for. (the name before the first .)"
+variable "certificate_name" {
+  description = "The certificate you are requesting (must be valid for the hosted zone)"
 }
 
 variable "create_wildcard" {
-  description = "If set to \"true\" also creates a wildcard certificate for the domain"
+  description = "If set to \"true\" also creates a wildcard certificate for the domain/subdomain"
   default     = "false"
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Added host variable

Fixes # (issue)

Previous change which removed the need to provide the hosted zone id since it could be inferred from the hosted zone name introduced an error when adding non wildcard domians

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Apply and destroy done of example and tested by ci pipeline

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/` directories (look in CI for an example)
- [x] Provide an updated example that utilizes newly created resources, or for more advanced additions a new example under the examples directory.
- [x] Docs have been added/updated (for bug fixes/features)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project