### PR TITLE
Upgrade terraform to 0.12

### DIFF
--- a/.ci/tasks/apply/task.yml
+++ b/.ci/tasks/apply/task.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: hashicorp/terraform
-    tag: "0.11.11"
+    tag: "0.12.5"
 
 params:
   AWS_ACCOUNT_ID:

--- a/.ci/tasks/destroy/task.yml
+++ b/.ci/tasks/destroy/task.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: hashicorp/terraform
-    tag: "0.11.11"
+    tag: "0.12.5"
 
 params:
   directory:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 
 before_install:
-  - curl -fSL "https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip" -o terraform.zip
+  - curl -fSL "https://releases.hashicorp.com/terraform/0.12.5/terraform_0.12.5_linux_amd64.zip" -o terraform.zip
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
   - rm -f terraform.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ before_install:
   - sudo unzip terraform.zip -d /opt/terraform
   - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
   - rm -f terraform.zip
-  - curl -fSL https://github.com/wata727/tflint/releases/download/v0.7.0/tflint_linux_amd64.zip -o tflint.zip
-  - sudo unzip tflint.zip -d /opt/tflint
-  - sudo ln -s /opt/tflint/tflint /usr/bin/tflint
-  - rm -f tflint.zip
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 	@for d in $$(find . -type f -name '*.tf' -path "./modules/*" -not -path "**/.terraform/*" -exec dirname {} \; | sort -u); do \
 		cd $$d; \
 		terraform init -backend=false >> /dev/null; \
-		terraform validate -check-variables=false; \
+		terraform validate; \
 		if [ $$? -eq 1 ]; then \
 			echo "✗ terraform validate failed: $$d"; \
 			exit 1; \
@@ -27,7 +27,7 @@ test:
 	@for d in $$(find . -type f -name '*.tf' -path "./examples/*" -not -path "**/.terraform/*" -exec dirname {} \; | sort -u); do \
 		cd $$d; \
 		terraform init -backend=false >> /dev/null; \
-		terraform validate -check-variables=false; \
+		terraform validate; \
 		if [ $$? -eq 1 ]; then \
 			echo "✗ terraform validate failed: $$d"; \
 			exit 1; \

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.12.5"
+  required_version = ">= 0.12.5"
 
   backend "s3" {
     key            = "terraform-modules/development/terraform-aws-acm-certificate/default.tfstate"
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  version             = "2.20.0"
+  version             = ">= 2.20.0"
   region              = "eu-west-1"
   allowed_account_ids = ["<test-account-id>"]
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.11.11"
+  required_version = "0.12.5"
 
   backend "s3" {
     key            = "terraform-modules/development/terraform-aws-acm-certificate/default.tfstate"
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  version             = "1.56.0"
+  version             = "2.20.0"
   region              = "eu-west-1"
   allowed_account_ids = ["<test-account-id>"]
 }
@@ -23,7 +23,7 @@ module "certificate" {
   hosted_zone_name = "<route53-zone-name>"
   certificate_name = "default-test.<route53-zone-name>"
 
-  tags {
+  tags = {
     environment = "dev"
     terraform   = "True"
   }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -30,5 +30,5 @@ module "certificate" {
 }
 
 output "certificate_arn" {
-  value = "${module.certificate.arn}"
+  value = module.certificate.arn
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.5"
+  required_version = ">= 0.12"
 
   backend "s3" {
     key            = "terraform-modules/development/terraform-aws-acm-certificate/default.tfstate"
@@ -13,7 +13,7 @@ terraform {
 }
 
 provider "aws" {
-  version             = ">= 2.20.0"
+  version             = ">= 2.20"
   region              = "eu-west-1"
   allowed_account_ids = ["<test-account-id>"]
 }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ resource "aws_acm_certificate" "main" {
 }
 
 locals {
-  test = var.create_wildcard == "true" ? 1 : 0
+  test = var.create_wildcard == true ? 1 : 0
 }
 
 data "aws_route53_zone" "main" {
@@ -20,7 +20,7 @@ data "aws_route53_zone" "main" {
 }
 
 resource "aws_acm_certificate" "wildcard" {
-  count             = var.create_wildcard == "true" ? 1 : 0
+  count             = var.create_wildcard == true ? 1 : 0
   domain_name       = "*.${var.certificate_name}"
   validation_method = "DNS"
   tags              = var.tags
@@ -42,7 +42,7 @@ resource "aws_route53_record" "cert_validation" {
 }
 
 resource "aws_acm_certificate_validation" "main" {
-  count           = var.wait_for_validation == "true" ? 1 : 0
+  count           = var.wait_for_validation == true ? 1 : 0
   certificate_arn = aws_acm_certificate.main.arn
 
   validation_record_fqdns = [
@@ -51,7 +51,7 @@ resource "aws_acm_certificate_validation" "main" {
 }
 
 resource "aws_acm_certificate_validation" "wildcard" {
-  count           = var.create_wildcard == "true" && var.wait_for_validation == "true" ? 1 : 0
+  count           = var.create_wildcard == true && var.wait_for_validation == true ? 1 : 0
   certificate_arn = aws_acm_certificate.wildcard[0].arn
 
   validation_record_fqdns = [

--- a/main.tf
+++ b/main.tf
@@ -2,9 +2,9 @@
 # Resource
 # ------------------------------------------------------------------------------
 resource "aws_acm_certificate" "main" {
-  domain_name       = "${var.certificate_name}"
+  domain_name       = var.certificate_name
   validation_method = "DNS"
-  tags              = "${var.tags}"
+  tags              = var.tags
 
   lifecycle {
     create_before_destroy = true
@@ -12,18 +12,18 @@ resource "aws_acm_certificate" "main" {
 }
 
 locals {
-  test = "${var.create_wildcard == "true" ? 1 : 0}"
+  test = var.create_wildcard == "true" ? 1 : 0
 }
 
 data "aws_route53_zone" "main" {
-  name = "${var.hosted_zone_name}"
+  name = var.hosted_zone_name
 }
 
 resource "aws_acm_certificate" "wildcard" {
-  count             = "${var.create_wildcard == "true" ? 1 : 0}"
+  count             = var.create_wildcard == "true" ? 1 : 0
   domain_name       = "*.${var.certificate_name}"
   validation_method = "DNS"
-  tags              = "${var.tags}"
+  tags              = var.tags
 
   lifecycle {
     create_before_destroy = true
@@ -31,30 +31,31 @@ resource "aws_acm_certificate" "wildcard" {
 }
 
 resource "aws_route53_record" "cert_validation" {
-  zone_id = "${data.aws_route53_zone.main.id}"
-  name    = "${aws_acm_certificate.main.domain_validation_options.0.resource_record_name}"
-  type    = "${aws_acm_certificate.main.domain_validation_options.0.resource_record_type}"
+  zone_id = data.aws_route53_zone.main.id
+  name    = aws_acm_certificate.main.domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.main.domain_validation_options[0].resource_record_type
   ttl     = 60
 
   records = [
-    "${aws_acm_certificate.main.domain_validation_options.0.resource_record_value}",
+    aws_acm_certificate.main.domain_validation_options[0].resource_record_value,
   ]
 }
 
 resource "aws_acm_certificate_validation" "main" {
-  count           = "${var.wait_for_validation == "true" ? 1 : 0}"
-  certificate_arn = "${aws_acm_certificate.main.arn}"
+  count           = var.wait_for_validation == "true" ? 1 : 0
+  certificate_arn = aws_acm_certificate.main.arn
 
   validation_record_fqdns = [
-    "${aws_route53_record.cert_validation.fqdn}",
+    aws_route53_record.cert_validation.fqdn,
   ]
 }
 
 resource "aws_acm_certificate_validation" "wildcard" {
-  count           = "${var.create_wildcard == "true" && var.wait_for_validation == "true" ? 1 : 0}"
-  certificate_arn = "${aws_acm_certificate.wildcard.arn}"
+  count           = var.create_wildcard == "true" && var.wait_for_validation == "true" ? 1 : 0
+  certificate_arn = aws_acm_certificate.wildcard[0].arn
 
   validation_record_fqdns = [
-    "${aws_route53_record.cert_validation.fqdn}",
+    aws_route53_record.cert_validation.fqdn,
   ]
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,20 +3,14 @@
 # ------------------------------------------------------------------------------
 output "arn" {
   description = "The ARN of the certificate that is being validated."
-  value = element(
-    concat(aws_acm_certificate_validation.main.*.certificate_arn, [""]),
-    0,
-  )
+  value       = concat(aws_acm_certificate_validation.main.*.certificate_arn, [""])
 }
 
 output "wildcard_arn" {
   description = "The ARN of the wildcard certificate that is being validated."
-  value = element(
-    concat(
-      aws_acm_certificate_validation.wildcard.*.certificate_arn,
-      [""],
-    ),
-    0,
+  value = concat(
+    aws_acm_certificate_validation.wildcard[*].certificate_arn,
+    [""],
   )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,10 +3,20 @@
 # ------------------------------------------------------------------------------
 output "arn" {
   description = "The ARN of the certificate that is being validated."
-  value       = "${element(concat(aws_acm_certificate_validation.main.*.certificate_arn, list("")), 0)}"
+  value = element(
+    concat(aws_acm_certificate_validation.main.*.certificate_arn, [""]),
+    0,
+  )
 }
 
 output "wildcard_arn" {
   description = "The ARN of the wildcard certificate that is being validated."
-  value       = "${element(concat(aws_acm_certificate_validation.wildcard.*.certificate_arn, list("")), 0)}"
+  value = element(
+    concat(
+      aws_acm_certificate_validation.wildcard.*.certificate_arn,
+      [""],
+    ),
+    0,
+  )
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,14 +3,11 @@
 # ------------------------------------------------------------------------------
 output "arn" {
   description = "The ARN of the certificate that is being validated."
-  value       = concat(aws_acm_certificate_validation.main.*.certificate_arn, [""])
+  value       = concat(aws_acm_certificate_validation.main[*].certificate_arn, [""])[0]
 }
 
 output "wildcard_arn" {
   description = "The ARN of the wildcard certificate that is being validated."
-  value = concat(
-    aws_acm_certificate_validation.wildcard[*].certificate_arn,
-    [""],
-  )
+  value       = concat(aws_acm_certificate_validation.wildcard[*].certificate_arn, [""])[0]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,8 @@ variable "certificate_name" {
 
 variable "create_wildcard" {
   description = "If set to \"true\" also creates a wildcard certificate for the domain/subdomain"
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "tags" {
@@ -22,6 +23,7 @@ variable "tags" {
 
 variable "wait_for_validation" {
   description = "If set to \"false\" this module will not wait for the validation to complete and will not return the certificate ARN"
-  default     = "true"
+  type        = bool
+  default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,10 +3,12 @@
 # ------------------------------------------------------------------------------
 variable "hosted_zone_name" {
   description = "The hosted zone"
+  type        = string
 }
 
 variable "certificate_name" {
   description = "The certificate you are requesting (must be valid for the hosted zone)"
+  type        = string
 }
 
 variable "create_wildcard" {
@@ -22,7 +24,7 @@ variable "tags" {
 }
 
 variable "wait_for_validation" {
-  description = "If set to \"false\" this module will not wait for the validation to complete and will not return the certificate ARN"
+  description = "If set to false this module will not wait for the validation to complete and will not return the certificate ARN"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "create_wildcard" {
 
 variable "tags" {
   description = "A map of tags (key-value pairs) passed to resources."
-  type        = "map"
+  type        = map(string)
   default     = {}
 }
 
@@ -24,3 +24,4 @@ variable "wait_for_validation" {
   description = "If set to \"false\" this module will not wait for the validation to complete and will not return the certificate ARN"
   default     = "true"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
The only breaking change is `tags {}` becoming `tags = {}` due to the new syntax in 0.12.